### PR TITLE
Updated the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ To install, download the latest release from the releases page and move the bina
 Or if you're lazy run, as root, the `install.sh` script.
 
 ### Usage
-All the config for MySQL mBak is stored in the config files. There are only two command line flags,
+All the config for MySQL mBak is stored in the config files. There are three command line flags,
 * `-v|-verbose`, which will enable the verbose output mode
 * `-h|-help` which will output the usage information.
+* `-version` which will output the current version number.
 
 ### Developing
 


### PR DESCRIPTION
The `-version` flag was missing from the usage section of the README
